### PR TITLE
Parse file mode in index to avoid parse error in `Parse()` of waigani/diffparser

### DIFF
--- a/github_diff.go
+++ b/github_diff.go
@@ -475,7 +475,7 @@ func parseGitDiffFileString(input string) (*GitDiff, error) {
 				return nil, errors.New("invalid file paths")
 			}
 		case strings.HasPrefix(line, "index "):
-			index = strings.TrimSpace(line[6:])
+			index = line[6:]
 		default:
 			diff = append(diff, line)
 		}


### PR DESCRIPTION
context: parsing the output of `ParseGitDiff()` using `Parse()` of waigani/diffparser
this PR resolves error below:

> could not parse line mode for line: "index 0000000..55e046e"

this error occurs from: https://github.com/waigani/diffparser/blob/7391f219313d9175703f67561b222fd2a81bca30/diffparser.go#L125